### PR TITLE
fix: change branch of "forge-std" to "master"

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,4 +1,4 @@
 [submodule "lib/forge-std"]
 	path = lib/forge-std
 	url = https://github.com/foundry-rs/forge-std
-	branch = v1.2.0
+	branch = master


### PR DESCRIPTION
> fatal: Unable to find refs/remotes/origin/v1.2.0 revision in submodule path 'lib/forge-std'